### PR TITLE
feat: Adds scale and expanded scale variables.

### DIFF
--- a/index.yml
+++ b/index.yml
@@ -1,2 +1,3 @@
 imports:
   - space/_space.yml
+  - space/_scale.yml

--- a/space/_scale.yml
+++ b/space/_scale.yml
@@ -1,0 +1,41 @@
+global:
+  type: size
+  category: Baseline
+props:
+  # TODO: derive from `baseline` and `baseline-scale` values in a way that works across all formatters
+  baseline-scale:
+    category: Baseline
+    type: scale
+    value:
+      - 2
+      - 3
+      - 4
+      - 6
+      - 9
+      - 12
+      - 18
+      - 24
+      - 36
+  baseline-1:
+    value: ".25rem"
+  baseline-2:
+    value: "0.50rem"
+  baseline-3:
+    value: "0.75rem"
+  baseline-4:
+    value: "1rem"
+  baseline-6:
+    value: "1.5rem"
+  baseline-9:
+    value: "2.25rem"
+  baseline-12:
+    value: "3rem"
+  baseline-18:
+    value: "4.5rem"
+  baseline-24:
+    value: "6rem"
+  baseline-36:
+    value: "9rem"
+
+  
+  

--- a/space/_space.yml
+++ b/space/_space.yml
@@ -1,7 +1,5 @@
-global:
-  type: size
-  category: Baseline
-
 props:
   baseline:
+    category: Baseline
+    type: size
     value: ".25rem"

--- a/token_names.json
+++ b/token_names.json
@@ -1,3 +1,14 @@
 [
-  "baseline"
+  "baseline",
+  "baseline-1",
+  "baseline-12",
+  "baseline-18",
+  "baseline-2",
+  "baseline-24",
+  "baseline-3",
+  "baseline-36",
+  "baseline-4",
+  "baseline-6",
+  "baseline-9",
+  "baseline-scale"
 ]


### PR DESCRIPTION
Right now, developers have to multiple `$baseline` by integers to get values along the scale. Although this is trivia, it does introduce a source of divergence from the design system should someone forget what the scale values are. This commit introduces expanded variables for the scale and the values.

Not the that while the `json`, `custom-properties`, and 'scss' module formats the scale itself correctly, the `common.js` formatter does not. I'm not quite sure why, but I'm also not certain it's necessary in that format. We can revisit that if necessary though.

### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### New Feature Submissions:

1. [X] Does your submission pass tests?
2. [X] Have you lint your code locally prior to submission?
